### PR TITLE
Changes to self service listing update PR 7

### DIFF
--- a/product-features/liquidity-pools/faqs.md
+++ b/product-features/liquidity-pools/faqs.md
@@ -116,7 +116,7 @@ Yes! [Self-Service Listing](../self-service-listing.md) allows you to create you
 
 <summary>Which are the anchor tokens supported?</summary>
 
-Native STX currency, ALEX token and aBTC token.
+Native STX token, ALEX token and aBTC token.
 
 </details>
 
@@ -124,7 +124,7 @@ Native STX currency, ALEX token and aBTC token.
 
 <summary>Is there a minimum liquidity amount for the anchor token?</summary>
 
-Yes. Initial liquidity of the anchor token must be a minimum of 1,800 STX or the equivalent value in in ALEX or aBTC tokens.
+Yes. Initial liquidity of the anchor token must be a minimum of 1,800 STX or the equivalent value in ALEX or aBTC tokens.
 
 </details>
 
@@ -153,7 +153,7 @@ Once the pool is created, the price discovery phase begins. Users can permission
 
 <details>
 
-<summary>Is there some requirement to make the listed token visible in ALEX Token List?</summary>
+<summary>Is there some requirement to make the listed token visible on [ALEX Token List](https://app.alexlab.co/token-list)?</summary>
 
 Yes. ALEX requires a [Coingecko](https://www.coingecko.com/) or [CoinMarketCap](https://coinmarketcap.com/) token listing to verify the provided social media information before uploading it to the official list at [app.alexlab.co/token-list](https://app.alexlab.co/token-list).
 
@@ -165,7 +165,7 @@ Once that is done, click on `Customer Support` on the [Self-Service Listing page
 
 <summary>What is a wrapped version of a token contract?</summary>
 
-Wrapped token contracts refer to "pass-through" tokens that don't retain economics; their purpose is to simplify development and enhance security. ALEX is responsible for deploying wrapped contracts. As its primarily technical, it is not relevant from a user perspective rather than it involves a whole step in the procedure and takes some time.
+Wrapped token contracts refer to "pass-through" tokens that don't retain economics; their purpose is to simplify development and enhance security. ALEX is responsible for deploying wrapped contracts. As its primarily technical, it is not relevant from a user perspective other than it involves a whole step in the procedure and takes some time.
 
 </details>
 
@@ -179,9 +179,9 @@ Wrapped contract FAQs, maybe necessary in the future.
 
 <summary>Is it possible to avoid wrapped contract deployment?</summary>
 
-Yes. However this may not speed the waiting time and requires some conditions in the token contract. 
+Yes. However, this may not speed up the waiting time and requires some conditions in the token contract. 
 
-You won't need a wrapped version of the token if this two conditions are met:
+You won't need a wrapped version of the token if these two conditions are met:
 
 1. Your token contract complies with ALEX's fungible token trait. This trait is the regular SIP-10 Standard Token Trait plus the helper functions for 8-digit fixed notation. See source code on [explorer](https://explorer.hiro.so/txid/0xd8d41e686264b1f8f7b3bd13016f00baf69d98c89c2aa588b5b96b5164d83e1d?chain=mainnet).
 2. Your token has 8 decimals. 

--- a/product-features/liquidity-pools/faqs.md
+++ b/product-features/liquidity-pools/faqs.md
@@ -168,24 +168,3 @@ Once that is done, click on `Customer Support` on the [Self-Service Listing page
 Wrapped token contracts refer to "pass-through" tokens that don't retain economics; their purpose is to simplify development and enhance security. ALEX is responsible for deploying wrapped contracts. As its primarily technical, it is not relevant from a user perspective other than it involves a whole step in the procedure and takes some time.
 
 </details>
-
-<!-- 
-
-Wrapped contract FAQs, maybe necessary in the future.
-
-
-
-<details>
-
-<summary>Is it possible to avoid wrapped contract deployment?</summary>
-
-Yes. However, this may not speed up the waiting time and requires some conditions in the token contract. 
-
-You won't need a wrapped version of the token if these two conditions are met:
-
-1. Your token contract complies with ALEX's fungible token trait. This trait is the regular SIP-10 Standard Token Trait plus the helper functions for 8-digit fixed notation. See source code on [explorer](https://explorer.hiro.so/txid/0xd8d41e686264b1f8f7b3bd13016f00baf69d98c89c2aa588b5b96b5164d83e1d?chain=mainnet).
-2. Your token has 8 decimals. 
-
-</details> 
-
--->

--- a/product-features/self-service-listing.md
+++ b/product-features/self-service-listing.md
@@ -19,16 +19,16 @@ Pool creation usually takes between 24 to 48 hours. Once the pool is created and
 The pool owner is the initial liquidity provider and will receive the corresponding LP tokens upon successful pool creation. Once the pool is live and operational, the owner can withdraw funds just like any other liquidity provider.
 
 {% hint style="info" %}
-Avaiblable Anchor Tokens: Native _STX_ currency, _ALEX_ token and _aBTC_ token.
+Avaiblable Anchor Tokens: Native _STX_ token, _ALEX_ token and _aBTC_ token.
 {% endhint %}
 
 The trading pool operates under the [ALEX Automated Market Maker (AMM)](../../detailed-information/alexs-automated-market-maker-amm.md) algorithm, which dynamically determines the exchange rate (price) based on the trades.
 
 ### Minimum requirements
 
-👉 **Token Deployment.** Have your token deployed on Stacks blockchain since you will need to provide the token contract.
+👉 **Token Deployment.** Ensure your token is deployed on the Stacks blockchain, as you will need to provide the token contract.
 
-👉 **Select an Anchor Token.** Choose an anchor token from the available options: Stacks native currency _STX_, _ALEX_ token, or _aBTC_ token. Ensure you have at least 1,800 _STX_ or an equivalent value in _ALEX_ or _aBTC_ token to create the pool—this is the minimum anchor token liquidity.
+👉 **Select an Anchor Token.** Choose an anchor token from the available options: Stacks native token _STX_, _ALEX_ token, or _aBTC_ token. Ensure you have at least 1,800 _STX_ or an equivalent value in _ALEX_ or _aBTC_ token to create the pool—this is the minimum anchor token liquidity.
 
 👉 **Determine Initial Price.** Decide the initial price for your listing token in terms of anchor token units. This should answer the question: how many anchor tokens do users need to buy one listed token?
 
@@ -110,7 +110,7 @@ Once the pool opens, the AMM algorithm will automatically rebalance the exchange
 
 This step is optional, as the default settings are usually sufficient.
 
-However, we recomend consulting the [ALEXGo Technical documentation](https://docs.alexgo.io/automated-market-making/trading-pool) before making customizations. If you have any questions, feel free to reach out via [Discord](https://discord.com/invite/alexlab) or [Telegram Channel](https://t.me/AlexCommunity).
+However, we recommend consulting the [ALEXGo Technical documentation](https://docs.alexgo.io/automated-market-making/trading-pool) before making customizations. If you have questions to ask before customization, reach out via [Discord](https://discord.com/invite/alexlab) or [Telegram](https://t.me/AlexCommunity).
 
 </details>
 
@@ -167,10 +167,10 @@ Summarized Steps:
 
 1) User submits token information, balances and config params. Within this same transaction, transfers the anchor token balance.
 
-2) User waits for token confirmation from ALEX side (this involves deploying the wrapped version, but the user doesn't get to know this detail).
+2) User waits for token confirmation from ALEX
 
 3) User deposits the listed token balance.
 
-4) Once this tx is confirmed, the pool is automatically created and available? (if start-block is configured "On finalization")
+4) Once this tx is confirmed, the pool is automatically created and available (if start-block is configured "On finalization").
 
 -->


### PR DESCRIPTION
Added the changes from PR 7.
The only thing left to decide is if the <details> section should be removed in product-features/liquidity-pools/faqs.md since it was suggested that it should not be displayed to the users.
The wording in product-features/self-service-listing.md was slightly modified to maintain the recommendation to consult the documentation and direct users to the Telegram and Discord channels if necessary.